### PR TITLE
Remove ability to log all script users IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ Just enter the code in the search box to get the full country name.
 For local usage, download the script:
 
 ```bash
-wget -O ipregion.sh https://ipregion.vrnt.xyz
+wget -O ipregion.sh https://raw.githubusercontent.com/vernette/ipregion/refs/heads/master/ipregion.sh
 chmod +x ipregion.sh
 ```
 
 Or run directly from GitHub:
 
 ```bash
-bash <(wget -qO- https://ipregion.vrnt.xyz)
+bash <(wget -qO- https://raw.githubusercontent.com/vernette/ipregion/refs/heads/master/ipregion.sh)
 ```
 
 ### Common use cases


### PR DESCRIPTION
Using a custom URL instead of a direct GitHub link allows the host to log every script download and the source IP address. It also introduces a security risk: the server hosting the custom URL (ipregion.vrnt.xyz) could be compromised, and the script replaced with a malicious one. This is not possible when using a direct GitHub link