### PR TITLE
docs(README): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ Just enter the code in the search box to get the full country name.
 
 Contributions are welcome! Feel free to submit pull requests to add new services or improve the script’s functionality.
 
-![Star History Chart](https://api.star-history.com/svg?repos=vernette/ipregion&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=vernette/ipregion&type=Date)


### PR DESCRIPTION
The star history chart in the README no longer renders because the underlying provider is affected by GitHub stargazer API restrictions. This changes the chart to a working data source that requires no API token, so the chart displays correctly for visitors.